### PR TITLE
feat: add basic `parser` and `notation` submodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: detect-private-key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "sat-rs"
-version = "0.0.1"
+version = "0.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "sat-rs"
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 description = "A SAT solver written in Rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/bin/problem.cnf
+++ b/bin/problem.cnf
@@ -1,0 +1,4 @@
+c A sample .cnf file.
+p cnf 3 2
+1 -3 0
+2 3 -1 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod notation;
+pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,26 @@
+use std::io;
+use std::io::Read;
+
+use notation::problem::Problem;
+
+mod notation;
+mod parser;
+
+use parser::cnfparser;
+
 fn main() {
-    println!("SAT Solver written in Rust");
+    // SAT Solver written in Rust
+    // Usage: cat problem.cnf | ./sat
+
+    // Read from stdin
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer).unwrap();
+
+    // Print the contents of the file
+    println!("{}", buffer);
+
+    let _prob: Problem = cnfparser::parse_cnf(&buffer);
+
+    // Parse the problem
+    // let _problem = parse(&problem);
 }

--- a/src/notation/clauses.rs
+++ b/src/notation/clauses.rs
@@ -1,0 +1,19 @@
+use std::fmt::Debug;
+
+use notation::literals::Literal;
+
+pub struct Clause {
+    literals: Vec<Literal>,
+}
+
+impl Clause {
+    pub fn new(literals: Vec<Literal>) -> Clause {
+        Clause { literals: literals }
+    }
+}
+
+impl Debug for Clause {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Clause {{ literals: {:?} }}", self.literals)
+    }
+}

--- a/src/notation/literals.rs
+++ b/src/notation/literals.rs
@@ -1,0 +1,27 @@
+use std::fmt::Debug;
+
+use notation::variables::Variable;
+
+pub struct Literal {
+    variable: Variable,
+    negated: bool,
+}
+
+impl Literal {
+    pub fn new(variable: Variable, negated: bool) -> Literal {
+        Literal {
+            variable: variable,
+            negated: negated,
+        }
+    }
+}
+
+impl Debug for Literal {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Literal {{ variable: {:?}, negated: {:?} }}",
+            self.variable, self.negated
+        )
+    }
+}

--- a/src/notation/mod.rs
+++ b/src/notation/mod.rs
@@ -1,0 +1,4 @@
+pub mod clauses;
+pub mod literals;
+pub mod problem;
+pub mod variables;

--- a/src/notation/problem.rs
+++ b/src/notation/problem.rs
@@ -1,0 +1,29 @@
+use std::fmt::Debug;
+
+use notation::clauses::Clause;
+
+pub struct Problem {
+    clauses: Vec<Clause>,
+    num_clauses: u32,
+    num_variables: u32,
+}
+
+impl Problem {
+    pub fn new(clauses: Vec<Clause>, num_clauses: u32, num_variables: u32) -> Problem {
+        Problem {
+            clauses: clauses,
+            num_clauses: num_clauses,
+            num_variables: num_variables,
+        }
+    }
+}
+
+impl Debug for Problem {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Problem {{ clauses: {:?}, num_clauses: {:?}, num_variables: {:?} }}",
+            self.clauses, self.num_clauses, self.num_variables
+        )
+    }
+}

--- a/src/notation/variables.rs
+++ b/src/notation/variables.rs
@@ -1,0 +1,17 @@
+use std::fmt::Debug;
+
+pub struct Variable {
+    name: String,
+}
+
+impl Variable {
+    pub fn new(name: String) -> Variable {
+        Variable { name: name }
+    }
+}
+
+impl Debug for Variable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Variable {{ name: {:?} }}", self.name)
+    }
+}

--- a/src/parser/cnfparser.rs
+++ b/src/parser/cnfparser.rs
@@ -1,0 +1,49 @@
+use notation::literals::Literal;
+use notation::problem::Problem;
+
+use notation::clauses::Clause;
+use notation::variables::Variable;
+
+pub fn parse_cnf(_buffer: &str) -> Problem {
+    let mut num_clauses: u32 = 0;
+    let mut num_variables: u32 = 0;
+    let mut clauses: Vec<Clause> = Vec::new();
+
+    for line in _buffer.lines() {
+        if line.starts_with("c") {
+            continue;
+        } else if line.starts_with("p") {
+            (num_variables, num_clauses) = parse_problem_line(line);
+        } else {
+            let literals: Vec<Literal> = parse_clause_line(line);
+            let clause: Clause = Clause::new(literals);
+            clauses.push(clause);
+        }
+    }
+
+    assert_eq!(clauses.len() as u32, num_clauses);
+
+    let prob = Problem::new(clauses, num_clauses, num_variables);
+    println!("{:?}", prob);
+    prob
+}
+
+fn parse_problem_line(_line: &str) -> (u32, u32) {
+    let contents: Vec<&str> = _line.split_whitespace().collect();
+    let num_variables: u32 = contents[2].parse().unwrap();
+    let num_clauses: u32 = contents[3].parse().unwrap();
+    (num_variables, num_clauses)
+}
+
+fn parse_clause_line(_line: &str) -> Vec<Literal> {
+    let mut clause: Vec<&str> = _line.split_whitespace().collect();
+    clause.pop();
+    let mut literals: Vec<Literal> = Vec::new();
+    for literal in clause {
+        let variable: String = literal.to_string();
+        let negated: bool = variable.starts_with("-");
+        let literal: Literal = Literal::new(Variable::new(variable), negated);
+        literals.push(literal);
+    }
+    literals
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,1 @@
+pub mod cnfparser;

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,0 +1,10 @@
+extern crate sat_rs;
+use sat_rs::parser::cnfparser;
+
+#[test]
+fn test_parse_cnf() {
+    // Create a buffer of type &str using file at bin/problem.cnf
+    let buffer = include_str!("../bin/problem.cnf");
+    // Parse the buffer
+    let _prob = cnfparser::parse_cnf(&buffer);
+}


### PR DESCRIPTION
- Adds a basic `notation` submodule following a struct based hierarchical design as follows, Every problem contains some clauses. Every clause contains some literals which are itself named variables with some properties such as (`negated`).
- Contains a custom `Debug` trait allowing for pretty printing of Problems.
- Adds a basic `parser` submodule allowing to read a `.cnf` file into a `Problem` struct.
- Adds a basic test for the `parser` using a sample cnf file at `bin/problem.cnf`.
- Adds a pre-commit configuration file at (`.pre-commit-config.yaml`).

[_This release follows the `0.0.2` release of the library._](https://crates.io/crates/sat-rs)